### PR TITLE
Adds support for environment vars

### DIFF
--- a/templates/supervisord.conf.j2
+++ b/templates/supervisord.conf.j2
@@ -9,7 +9,12 @@
 [{{ section_label }}:{{ section.name }}]
 {% for option, value in section.items() %}
 {% if option != 'name' %}
+{% if option == 'environment' and value is iterable and value is not string %}
+{{ option }} ={% for k,v in value.iteritems() %}{{ k }}="{{v}}", {% endfor %} 
+
+{% else %}
 {{ option }} = {{ value }}
+{% endif %}
 {% endif %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
Add support for environment option

``` yaml
- name: phpWorker
  environment:
    MYSQL_HOST: "127.0.0.1"
    MYSQL_PORT: 3306
  command: php worker.php
```

generates inside supervisord.conf

```
[program:phpWorker]
environment= MYSQL_HOST="127.0.0.1", MYSQL_PORT="3306",
command=php worker.php
```
